### PR TITLE
Move dep side and dep ordering

### DIFF
--- a/Test/gradle/wrapper/gradle-wrapper.properties
+++ b/Test/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/Test/src/main/resources/META-INF/mods.groovy
+++ b/Test/src/main/resources/META-INF/mods.groovy
@@ -1,7 +1,7 @@
 //file:noinspection GrPackage
 ModsDotGroovy.make {
     modLoader = 'gml'
-    loaderVersion = '[1.0,'
+    loaderVersion = '[1,'
 
     license = 'MIT'
 
@@ -19,8 +19,8 @@ ModsDotGroovy.make {
             mod {
                 modId = 'patchouli'
                 versionRange = '[1.1,)'
-                ordering = modsdotgroovy.DependencyOrdering.AFTER
-                side = modsdotgroovy.DependencySide.BOTH
+                ordering = DependencyOrdering.AFTER
+                side = DependencySide.BOTH
             }
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -53,8 +53,8 @@ gradlePlugin {
     }
 }
 
-jar {
-    manifest.attributes makeAttributes()
+tasks.named('jar', Jar) {
+    it.manifest.attributes makeAttributes()
 }
 
 Map<?, ?> makeAttributes() {
@@ -72,17 +72,23 @@ Map<?, ?> makeAttributes() {
     ]
 }
 
-tasks.create('dslJar', Jar) {
+tasks.register('dslJar', Jar) {
     group = 'build'
     from sourceSets.lib.output
     archiveFileName = "dsl-${project.dsl_version}.jar"
-    manifest.attributes makeAttributes() + ['Maven-Artifact' : "${project.group}:dsl:${project.version}"]
+    it.manifest.attributes makeAttributes() + ['Maven-Artifact' : "${project.group}:dsl:${project.version}"]
 }
-tasks.create('dslSources', Jar) {
+
+tasks.register('dslSources', Jar) {
     from sourceSets.lib.allSource
     archiveFileName = "dsl-${project.dsl_version}-sources.jar"
     classifier 'sources'
-    manifest.attributes makeAttributes()
+    it.manifest.attributes makeAttributes()
+}
+
+tasks.withType(GroovyCompile).configureEach {
+    groovyOptions.encoding = 'UTF-8'
+    groovyOptions.optimizationOptions.indy = true
 }
 
 publishing {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/lib/groovy/DependencyOrdering.groovy
+++ b/src/lib/groovy/DependencyOrdering.groovy
@@ -22,11 +22,11 @@
  * SOFTWARE.
  */
 
-package modsdotgroovy
+
 
 import groovy.transform.CompileStatic
 
 @CompileStatic
-enum DependencySide {
-    CLIENT, SERVER, BOTH
+enum DependencyOrdering {
+    BEFORE, AFTER, NONE
 }

--- a/src/lib/groovy/DependencySide.groovy
+++ b/src/lib/groovy/DependencySide.groovy
@@ -22,11 +22,11 @@
  * SOFTWARE.
  */
 
-package modsdotgroovy
+
 
 import groovy.transform.CompileStatic
 
 @CompileStatic
-enum DependencyOrdering {
-    BEFORE, AFTER, NONE
+enum DependencySide {
+    CLIENT, SERVER, BOTH
 }


### PR DESCRIPTION
Also update and speed up the Gradle build a bit.

Before:
```groovy
mod {
    modId = 'patchouli'
    versionRange = '[1.1,)'
    ordering = modsdotgroovy.DependencyOrdering.AFTER
    side = modsdotgroovy.DependencySide.BOTH
}
```

After, without needing an import:
```groovy
mod {
    modId = 'patchouli'
    versionRange = '[1.1,)'
    ordering = DependencyOrdering.AFTER
    side = DependencySide.BOTH
}
```