### PR TITLE
Support custom mod properties

### DIFF
--- a/Test/src/main/resources/mods.groovy
+++ b/Test/src/main/resources/mods.groovy
@@ -10,6 +10,8 @@ ModsDotGroovy.make {
 
         credits = "${buildProperties.someProperty}"
 
+        customProperty = 'hello'
+
         dependencies {
             minecraft {
                 versionRange = '[1.19,1.20)'

--- a/src/lib/groovy/ModsDotGroovy.groovy
+++ b/src/lib/groovy/ModsDotGroovy.groovy
@@ -25,7 +25,6 @@
 import groovy.transform.CompileStatic
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
-import modsdotgroovy.DependenciesBuilder
 import modsdotgroovy.ImmutableModInfo
 import modsdotgroovy.ModInfoBuilder
 import modsdotgroovy.ModsBuilder
@@ -101,8 +100,10 @@ class ModsDotGroovy {
                     .computeIfAbsent(modInfo.modId, {[]}) as List)
                     .push(it.asMap())
         }
-        final modData = [:]
 
+        put('modproperties', ["${modInfo.modId}": modInfo.customProperties])
+
+        final modData = [:]
         modData['modId'] = modInfo.modId
         modData['version'] = modInfo.version
         modData['displayName'] = modInfo.displayName

--- a/src/lib/groovy/ModsDotGroovy.groovy
+++ b/src/lib/groovy/ModsDotGroovy.groovy
@@ -100,8 +100,9 @@ class ModsDotGroovy {
                     .computeIfAbsent(modInfo.modId, {[]}) as List)
                     .push(it.asMap())
         }
-
-        put('modproperties', ["${modInfo.modId}": modInfo.customProperties])
+        if (!modInfo.customProperties.isEmpty())
+        (data.computeIfAbsent('modproperties', {[:]}) as Map)
+                .put(modInfo.modId, modInfo.customProperties)
 
         final modData = [:]
         modData['modId'] = modInfo.modId

--- a/src/lib/groovy/modsdotgroovy/ImmutableModInfo.groovy
+++ b/src/lib/groovy/modsdotgroovy/ImmutableModInfo.groovy
@@ -46,5 +46,5 @@ class ImmutableModInfo {
     String description
 
     List<Dependency> dependencies
-    Map<String, String> customProperties
+    Map customProperties
 }

--- a/src/lib/groovy/modsdotgroovy/ImmutableModInfo.groovy
+++ b/src/lib/groovy/modsdotgroovy/ImmutableModInfo.groovy
@@ -46,4 +46,5 @@ class ImmutableModInfo {
     String description
 
     List<Dependency> dependencies
+    Map<String, String> customProperties
 }

--- a/src/lib/groovy/modsdotgroovy/ModInfoBuilder.groovy
+++ b/src/lib/groovy/modsdotgroovy/ModInfoBuilder.groovy
@@ -90,6 +90,15 @@ class ModInfoBuilder {
      */
     List<Dependency> dependencies
 
+    /**
+     * The custom properties of the mod
+     */
+    Map<String, String> properties = [:]
+
+    void propertyMissing(String name, String value) {
+        properties[name] = value
+    }
+
     void dependencies(@DelegatesTo(value = DependenciesBuilder, strategy = DELEGATE_FIRST)
                       @ClosureParams(value = SimpleType, options = 'modsdotgroovy.DependenciesBuilder') final Closure closure) {
         final dependenciesBuilder = new DependenciesBuilder()
@@ -112,6 +121,6 @@ class ModInfoBuilder {
     }
 
     ImmutableModInfo build() {
-        return new ImmutableModInfo(this.modId, this.displayName, this.version, this.updateJsonUrl, this.displayUrl, this.logoFile, this.credits, this.authors, this.description, this.dependencies)
+        return new ImmutableModInfo(this.modId, this.displayName, this.version, this.updateJsonUrl, this.displayUrl, this.logoFile, this.credits, this.authors, this.description, this.dependencies, this.properties)
     }
 }

--- a/src/lib/groovy/modsdotgroovy/ModInfoBuilder.groovy
+++ b/src/lib/groovy/modsdotgroovy/ModInfoBuilder.groovy
@@ -93,9 +93,9 @@ class ModInfoBuilder {
     /**
      * The custom properties of the mod
      */
-    Map<String, String> properties = [:]
+    Map properties = [:]
 
-    void propertyMissing(String name, String value) {
+    void propertyMissing(String name, Object value) {
         properties[name] = value
     }
 


### PR DESCRIPTION
Add support for custom mod properties

```groovy
mod {
    modId = 'no'

    customProperty = 'hello'
    // ...
}
```

```toml
[modproperties.no]
    customProperty = "hello"
```