### PR TITLE
Smart authors string feature

### DIFF
--- a/Test/src/main/resources/mods.groovy
+++ b/Test/src/main/resources/mods.groovy
@@ -8,6 +8,7 @@ ModsDotGroovy.make {
         modId = 'no'
         version = '1.190'
 
+        authors = ['Matyrobbrt', 'Paint_Ninja']
         credits = "${buildProperties.someProperty}"
 
         dependencies {

--- a/src/lib/groovy/ModsDotGroovy.groovy
+++ b/src/lib/groovy/ModsDotGroovy.groovy
@@ -111,7 +111,26 @@ class ModsDotGroovy {
         modData['credits'] = modInfo.credits
         modData['logoFile'] = modInfo.logoFile
         modData['description'] = modInfo.description
-        modData['authors'] = modInfo.authors
+
+        String authorsString = ''
+        switch (modInfo.authors.size()) {
+            case 0:
+                break
+            case 1:
+                authorsString = modInfo.authors[0]
+                break
+            case 2:
+                authorsString = modInfo.authors[0] + ' and ' + modInfo.authors[1]
+                break
+            default:
+                modInfo.authors.eachWithIndex { String entry, int i ->
+                    if (i == 0) authorsString = entry
+                    else if (i == modInfo.authors.size() - 1) authorsString += ' and ' + entry
+                    else authorsString += ', ' + entry
+                }
+                break
+        }
+        modData['authors'] = authorsString
 
         mods.add(modData)
     }

--- a/src/lib/groovy/modsdotgroovy/ModInfoBuilder.groovy
+++ b/src/lib/groovy/modsdotgroovy/ModInfoBuilder.groovy
@@ -70,18 +70,25 @@ class ModInfoBuilder {
      */
     @Nullable String logoFile = null
 
+    /**
+     * People you give credits for the mod.
+     */
     @Nullable String credits = null
+
+    /**
+     * The authors of the mod. <br>
+     * MDT will automatically format them as 'x, y and z'.
+     */
     List<String> authors = []
 
     /**
      * Display Test controls the display for your mod in the server connection screen.<br>
      */
-    // only in 1.19+
+    // TODO make enum, and actually support
     //@Nullable String displayTest = null
 
     /**
-     * A multi-line description text for the mod, displayed in the in-game Mods screen.<br>
-     * Groovylicious will automatically strip the fixed length code indent for you.
+     * A multi-line description text for the mod, displayed in the in-game Mods screen. <br>
      */
     String description = ''
 


### PR DESCRIPTION
Converts the authors list into a string with appropriate wording and formatting.

For example:
```groovy
authors = ['Matyrobbrt', 'Paint_Ninja', 'Anonymous']

authors = ['Matyrobbrt', 'Paint_Ninja']
```
```toml
authors = "Matyrobbrt, Paint_Ninja and Anonymous"

authors = "Matyrobbrt and Paint_Ninja"
```