### PR TITLE
Minor cleanup, add more validation

### DIFF
--- a/Test/build.gradle
+++ b/Test/build.gradle
@@ -1,13 +1,13 @@
 plugins {
     id 'java'
-    id 'io.github.groovymc.modsdotgroovy' version '1.0.0'
+    id 'io.github.groovymc.modsdotgroovy' version '1.1.0'
 }
 
 java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
 modsDotGroovy {
-    dslVersion = '1.0.2'
-    platforms 'forge','quilt'
+    dslVersion = '1.1.3'
+    platforms 'forge', 'quilt'
 }
 
 repositories {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.parallel=true
 org.gradle.caching=true
 
 version=1.1.0
-dsl_version=1.1.2
+dsl_version=1.1.3

--- a/src/lib/groovy/ModsDotGroovy.groovy
+++ b/src/lib/groovy/ModsDotGroovy.groovy
@@ -39,12 +39,9 @@ class ModsDotGroovy {
     protected Map data
 
     protected ModsDotGroovy() {
-        switch (platform) {
-            case Platform.QUILT:
-                this.data = ["schema_version":1, "quilt_loader":[:]]
-                break
-            case Platform.FORGE:
-                this.data = [:]
+        this.data = switch (platform) {
+            case Platform.QUILT -> ["schema_version": 1, "quilt_loader": [:]]
+            case Platform.FORGE -> [:]
         }
     }
 
@@ -93,7 +90,7 @@ class ModsDotGroovy {
                 put 'license', license
                 break
             case Platform.QUILT:
-                this.data = merge(this.data, ["quilt_loader":["metadata":["license":license]]])
+                this.data = merge(this.data, ["quilt_loader": ["metadata": ["license": license]]])
         }
     }
 
@@ -106,7 +103,7 @@ class ModsDotGroovy {
                 put 'issueTrackerURL', issueTrackerUrl
                 break
             case Platform.QUILT:
-                this.data = merge(this.data, ["quilt_loader":["metadata":["contact":["issues":issueTrackerUrl]]]])
+                this.data = merge(this.data, ["quilt_loader": ["metadata": ["contact": ["issues": issueTrackerUrl]]]])
         }
     }
 
@@ -208,7 +205,7 @@ class ModsDotGroovy {
                 }
 
                 if (modInfo.customProperties !== null && !modInfo.customProperties.isEmpty())
-                    this.data = merge(this.data, ['quilt_loader':modInfo.customProperties])
+                    this.data = merge(this.data, ['quilt_loader': modInfo.customProperties])
 
                 boolean otherQuiltModsExist = (this.data?.quilt_loader as Map)?.id !== null
 
@@ -220,7 +217,7 @@ class ModsDotGroovy {
                 } else {
                     quiltModData.computeIfAbsent('provides', {[]})
                     List provides = quiltModData['provides'] as List
-                    provides.add(['id':modInfo.modId,'version':modInfo.version])
+                    provides.add(['id': modInfo.modId, 'version': modInfo.version])
                 }
                 quiltMetadata['name'] = modInfo.displayName
                 quiltMetadata['contact'] = ["homepage":modInfo.displayUrl]
@@ -234,7 +231,7 @@ class ModsDotGroovy {
                 }
                 quiltMetadata['contributors'] = quiltContributors
                 quiltModData['metadata'] = quiltMetadata
-                this.data = merge(this.data, ["quilt_loader":quiltModData])
+                this.data = merge(this.data, ["quilt_loader": quiltModData])
         }
     }
 

--- a/src/lib/groovy/modsdotgroovy/AdaptedBuilder.groovy
+++ b/src/lib/groovy/modsdotgroovy/AdaptedBuilder.groovy
@@ -31,7 +31,7 @@ class AdaptedBuilder {
     /**
      * Points towards the implementation of the entrypoint, to be loaded by the adapter.
      */
-    String value
+    String value = null
 
     /**
      * The adapter to use when loading the entrypoint value.
@@ -39,8 +39,8 @@ class AdaptedBuilder {
     String adapter = 'default'
 
     Map build() {
-        if (!value)
-            throw new IllegalArgumentException("A value must be provided for an entrypoint with an adapter.")
-        return ['adapter':adapter,'value':value]
+        Objects.requireNonNull(value, 'A value must be provided for an entrypoint with an adapter.')
+
+        return ['adapter': adapter, 'value': value]
     }
 }

--- a/src/lib/groovy/modsdotgroovy/Dependency.groovy
+++ b/src/lib/groovy/modsdotgroovy/Dependency.groovy
@@ -31,7 +31,7 @@ class Dependency {
     /**
      * The ID of the mod this dependency is depending on.
      */
-    String modId
+    String modId = null
 
     /**
      * Does this dependency have to exist? If not, ordering must also be specified.
@@ -41,7 +41,7 @@ class Dependency {
     /**
      * A version range of the versions of the mod you're compatible with.
      */
-    VersionRange versionRange
+    VersionRange versionRange = null
 
     /**
      * An ordering relationship for the dependency - BEFORE or AFTER required if the relationship is not mandatory
@@ -110,15 +110,10 @@ class Dependency {
     }
 
     Dependency copy() {
-        if (!modId) throw new IllegalArgumentException("Missing modId for dependency")
-        if (!versionRange) throw new IllegalArgumentException("Missing versionRange for dependency $modId")
-        final dep = new Dependency()
-        dep.modId = modId
-        dep.mandatory = mandatory
-        dep.versionRange = versionRange
-        dep.ordering = ordering
-        dep.side = side
-        return dep
+        Objects.requireNonNull(modId, 'Missing modId for dependency')
+        Objects.requireNonNull(versionRange, "Missing versionRange for dependency $modId")
+
+        return new Dependency(modId: modId, mandatory: mandatory, versionRange: versionRange, ordering: ordering, side: side)
     }
 
 }

--- a/src/lib/groovy/modsdotgroovy/ModInfoBuilder.groovy
+++ b/src/lib/groovy/modsdotgroovy/ModInfoBuilder.groovy
@@ -38,7 +38,7 @@ class ModInfoBuilder {
     /**
      * The modId of the mod. This should match the value of your mod's {@literal @}GMod/{@literal @}Mod annotated main class.
      */
-    String modId = 'unknown'
+    String modId = null
 
     /**
      * The friendly name of the mod. This is the name that will be displayed in the in-game Mods screen.<br>
@@ -51,7 +51,7 @@ class ModInfoBuilder {
      * ${file.jarVersion} will substitute the value of the Implementation-Version as read from the mod's JAR file metadata.<br>
      * See the associated build.gradle script for how to populate this completely automatically during a build.
      */
-    String version = 'unknown'
+    String version = null
 
     /**
      * A URL to query for updates for this mod.<br>
@@ -148,6 +148,9 @@ class ModInfoBuilder {
     }
 
     ImmutableModInfo build() {
+        Objects.requireNonNull(this.modId, 'Missing modId for ModInfo')
+        Objects.requireNonNull(this.version, "Missing version for ModInfo with modId \"${this.modId}\"")
+
         return new ImmutableModInfo(this.modId, this.displayName ?: this.modId.capitalize(), this.version, this.updateJsonUrl, this.displayUrl, this.logoFile, this.credits, this.authors, this.description, this.dependencies, this.properties, this.entrypoints)
     }
 }


### PR DESCRIPTION
This PR makes the modId and version fields required and shows an error at build-time when missing. This helps avoid an issue where someone might've forgotten to set their modId and have an error launching Forge with the mod claiming it can't find "unknown".