### PR TITLE
Allow version catalogs to be used in scripts

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.parallel=true
 org.gradle.caching=true
 
-version=1.1.0
+version=1.1.1
 dsl_version=1.1.3

--- a/src/main/groovy/io/github/groovymc/modsdotgroovy/AbstractConvertTask.groovy
+++ b/src/main/groovy/io/github/groovymc/modsdotgroovy/AbstractConvertTask.groovy
@@ -28,9 +28,13 @@ import groovy.transform.CompileDynamic
 import groovy.transform.CompileStatic
 import org.codehaus.groovy.control.CompilerConfiguration
 import org.gradle.api.DefaultTask
+import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.VersionCatalog
+import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.api.file.CopySpec
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.internal.catalog.VersionCatalogView
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.*
@@ -79,10 +83,69 @@ if (ModsDotGroovy.metaClass.respondsTo(null,'setPlatform')) {
         arguments.convention(project.objects.mapProperty(String, Object))
         project.afterEvaluate {
             arguments.put('buildProperties', project.extensions.extraProperties.properties)
+            arg('libs', versionCatalogToMap(getLibsExtension(project)))
             arg('version', project.version)
             arg('platform', getPlatform())
             arg('group', project.group)
             setupPlatformSpecificArguments()
+        }
+    }
+
+    protected static VersionCatalog getLibsExtension(Project project) {
+        java.util.Optional<? extends VersionCatalog> catalogView = project.extensions.findByType(VersionCatalogsExtension)?.find('libs')
+        if (!catalogView.isEmpty() || project.parent === null) {
+            return catalogView.orElse(null)
+        }
+        return getLibsExtension(project.parent)
+    }
+
+    protected static Map versionCatalogToMap(VersionCatalog catalog) {
+        Map out = [:]
+        Map versions = [:]
+        Map plugins = [:]
+        Map bundles = [:]
+        out.versions = versions
+        out.plugins = plugins
+        out.bundles = bundles
+        if (catalog === null)
+            return [:]
+        catalog.versionAliases.each {
+            var val = catalog.findVersion(it)
+            if (val.isPresent())
+                writeByPartwise(versions, it, "${val.get()}" as String)
+        }
+        catalog.pluginAliases.each {
+            var val = catalog.findPlugin(it)
+            if (val.isPresent())
+                writeByPartwise(plugins, it, "${val.get().get()}" as String)
+        }
+        catalog.bundleAliases.each {
+            var val = catalog.findBundle(it)
+            if (val.isPresent()) {
+                var modules = val.get().get()
+                writeByPartwise(bundles, it, modules.collect {"${it}" as String})
+            }
+        }
+        catalog.libraryAliases.each {
+            var val = catalog.findLibrary(it)
+            if (val.isPresent())
+                writeByPartwise(out, it, "${val.get().get()}" as String)
+        }
+        return out
+    }
+
+    protected static void writeByPartwise(Map root, String path, Object value) {
+        List<String> parts = path.split(/\./).collect {it.trim()}.findAll {!it.isEmpty()}
+        if (parts.size() == 1)
+            root[parts[0]] = value
+        else if (parts.size() >= 1) {
+            Object inner = root.computeIfAbsent(parts[0], {[:]})
+            if (!(inner instanceof Map)) {
+                root[parts[0]] = [:]
+                inner = root[parts[0]]
+            }
+            writeByPartwise(inner as Map, parts.subList(1, parts.size()).join('.'), value)
+            root[parts[0]] = inner
         }
     }
 

--- a/src/main/groovy/io/github/groovymc/modsdotgroovy/MDGExtension.groovy
+++ b/src/main/groovy/io/github/groovymc/modsdotgroovy/MDGExtension.groovy
@@ -42,6 +42,7 @@ abstract class MDGExtension {
     abstract Property<SourceSet> getSource()
     abstract Property<MultiloaderConfiguration> getMultiloader()
     abstract MapProperty<String, Object> getArguments()
+    abstract ListProperty<String> getCatalogs()
 
     protected final Project project
 
@@ -50,6 +51,7 @@ abstract class MDGExtension {
         automaticConfiguration.set(true)
         platforms.set([Platform.FORGE])
         arguments.set([:])
+        catalogs.set(['libs'])
     }
 
     String mdgDsl(String version = null) {

--- a/src/main/groovy/io/github/groovymc/modsdotgroovy/MDGExtension.groovy
+++ b/src/main/groovy/io/github/groovymc/modsdotgroovy/MDGExtension.groovy
@@ -29,6 +29,7 @@ import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
 import org.gradle.api.Project
 import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.SourceSet
 
@@ -40,6 +41,7 @@ abstract class MDGExtension {
     abstract ListProperty<Platform> getPlatforms()
     abstract Property<SourceSet> getSource()
     abstract Property<MultiloaderConfiguration> getMultiloader()
+    abstract MapProperty<String, Object> getArguments()
 
     protected final Project project
 
@@ -47,6 +49,7 @@ abstract class MDGExtension {
         this.project = project
         automaticConfiguration.set(true)
         platforms.set([Platform.FORGE])
+        arguments.set([:])
     }
 
     String mdgDsl(String version = null) {

--- a/src/main/groovy/io/github/groovymc/modsdotgroovy/ModsDotGroovy.groovy
+++ b/src/main/groovy/io/github/groovymc/modsdotgroovy/ModsDotGroovy.groovy
@@ -74,11 +74,13 @@ class ModsDotGroovy implements Plugin<Project> {
                             case MDGExtension.Platform.FORGE:
                                 makeAndAppendForgeTask(modsGroovy, project).with {
                                     arguments.set(ext.arguments.get())
+                                    catalogs.set(ext.catalogs.get())
                                 }
                                 break
                             case MDGExtension.Platform.QUILT:
                                 makeAndAppendQuiltTask(modsGroovy, project).with {
                                     arguments.set(ext.arguments.get())
+                                    catalogs.set(ext.catalogs.get())
                                 }
                         }
                     } else {
@@ -108,12 +110,14 @@ class ModsDotGroovy implements Plugin<Project> {
                             makeAndAppendForgeTask(modsGroovy, it).with {
                                 dslConfiguration.set(commonConfiguration)
                                 arguments.set(ext.arguments.get())
+                                catalogs.set(ext.catalogs.get())
                             }
                         }
                         quilt.each {
                             makeAndAppendQuiltTask(modsGroovy, it).with{
                                 dslConfiguration.set(commonConfiguration)
                                 arguments.set(ext.arguments.get())
+                                catalogs.set(ext.catalogs.get())
                             }
                         }
                     }

--- a/src/main/groovy/io/github/groovymc/modsdotgroovy/ModsDotGroovy.groovy
+++ b/src/main/groovy/io/github/groovymc/modsdotgroovy/ModsDotGroovy.groovy
@@ -72,10 +72,14 @@ class ModsDotGroovy implements Plugin<Project> {
 
                         switch (platform) {
                             case MDGExtension.Platform.FORGE:
-                                makeAndAppendForgeTask(modsGroovy, project)
+                                makeAndAppendForgeTask(modsGroovy, project).with {
+                                    arguments.set(ext.arguments.get())
+                                }
                                 break
                             case MDGExtension.Platform.QUILT:
-                                makeAndAppendQuiltTask(modsGroovy, project)
+                                makeAndAppendQuiltTask(modsGroovy, project).with {
+                                    arguments.set(ext.arguments.get())
+                                }
                         }
                     } else {
                         final common = ext.multiloader.getOrNull()?.common ?: project.subprojects.find { it.name.toLowerCase(Locale.ROOT) == 'common' }
@@ -101,10 +105,16 @@ class ModsDotGroovy implements Plugin<Project> {
 
 
                         forge.each {
-                            makeAndAppendForgeTask(modsGroovy, it).dslConfiguration.set(commonConfiguration)
+                            makeAndAppendForgeTask(modsGroovy, it).with {
+                                dslConfiguration.set(commonConfiguration)
+                                arguments.set(ext.arguments.get())
+                            }
                         }
                         quilt.each {
-                            makeAndAppendQuiltTask(modsGroovy, it).dslConfiguration.set(commonConfiguration)
+                            makeAndAppendQuiltTask(modsGroovy, it).with{
+                                dslConfiguration.set(commonConfiguration)
+                                arguments.set(ext.arguments.get())
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
This PR has two changes: first, it adds an `arguments` property to the MDG extension, allowing arguments to be set for all generated tasks. Second, it parses the version catalog named `libs`, if it exists, into a map, and feeds that map as an argument to the script. The version catalogs parsed and added can be changed by changing the `catalogs` property of the task, which is set, by default, by the `catalogs` property of the extension.