### PR TITLE
Smart updateJsonUrl inference feature

### DIFF
--- a/Test/build.gradle
+++ b/Test/build.gradle
@@ -6,7 +6,7 @@ plugins {
 java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
 modsDotGroovy {
-    dslVersion = '1.1.4'
+    dslVersion = '1.2.0'
     platforms 'forge', 'quilt'
 }
 

--- a/Test/build.gradle
+++ b/Test/build.gradle
@@ -6,7 +6,7 @@ plugins {
 java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
 modsDotGroovy {
-    dslVersion = '1.2.0'
+    dslVersion = '1.1.4'
     platforms 'forge', 'quilt'
 }
 

--- a/Test/build.gradle
+++ b/Test/build.gradle
@@ -6,7 +6,7 @@ plugins {
 java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
 modsDotGroovy {
-    dslVersion = '1.1.3'
+    dslVersion = '1.1.4'
     platforms 'forge', 'quilt'
 }
 

--- a/Test/src/main/resources/mods.groovy
+++ b/Test/src/main/resources/mods.groovy
@@ -11,6 +11,9 @@ ModsDotGroovy.make {
         authors = ['Matyrobbrt', 'Paint_Ninja']
         credits = "${buildProperties.someProperty}"
 
+        // for testing the inferred updateJsonUrl feature - issueTrackerUrl and links to GitHub repos are also supported by this feature
+        displayUrl = 'https://curseforge.com/minecraft/mc-mods/spammycombat?projectId=623297'
+
         onForge {
             customProperty = 'hello'
         }

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,8 @@ license {
 
 dependencies {
     implementation gradleApi()
-    libCompileOnly "org.apache.groovy:groovy:4.0.4"
+    libCompileOnly 'org.apache.groovy:groovy:4.0.4'
+    libCompileOnly 'org.apache.groovy:groovy-json:4.0.4'
     implementation 'com.moandjiezana.toml:toml4j:0.7.2'
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.parallel=true
 org.gradle.caching=true
 
 version=1.1.2
-dsl_version=1.2.0
+dsl_version=1.1.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.parallel=true
 org.gradle.caching=true
 
 version=1.1.2
-dsl_version=1.1.3
+dsl_version=1.1.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.parallel=true
 org.gradle.caching=true
 
 version=1.1.2
-dsl_version=1.1.4
+dsl_version=1.2.0

--- a/src/lib/groovy/ModsDotGroovy.groovy
+++ b/src/lib/groovy/ModsDotGroovy.groovy
@@ -380,37 +380,6 @@ class ModsDotGroovy {
             }
         }
 
-        final Matcher mrMatcher = modInfo.displayUrl =~ $/.*modrinth.com/mod/([^?/]+)/?/$
-        println "displayUrl: ${modInfo.displayUrl}"
-        println "matches? ${mrMatcher.matches()}"
-        if (mrMatcher.matches()) {
-            httpClient ?= HttpClient.newBuilder().build()
-            final String updateJsonUrl = "https://api.modrinth.com/updates/${mrMatcher.group(1)}/forge_updates.json"
-
-            // modrinth's api doesn't factor in the actual mod jar's mods.toml version - just the published version,
-            // so we need to check that the returned promos map contains the mod's current version to avoid constantly
-            // nagging for updates the user might already have
-            final jsonSlurper = new JsonSlurper().setType(JsonParserType.INDEX_OVERLAY)
-            final HttpRequest request = HttpRequest.newBuilder(URI.create(updateJsonUrl)).GET().build()
-            try {
-                final HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
-                println response.statusCode()
-                if (response.statusCode() === HttpURLConnection.HTTP_OK) {
-                    final json = jsonSlurper.parseText(response.body())
-                    @Nullable final Map promos = json?.getAt('promos') as Map
-                    println "promos: ${promos}"
-                    if (promos !== null && !promos?.isEmpty()) {
-                        println "values: ${promos.values()}"
-                        println "contains? ${promos.values().contains(modInfo.version)}"
-                        if (promos.values().contains(modInfo.version))
-                            return updateJsonUrl
-                    }
-                }
-            } catch (final IOException ignored) {
-                println "ioexception"
-            }
-        }
-
         return null
     }
 }

--- a/src/lib/groovy/ModsDotGroovy.groovy
+++ b/src/lib/groovy/ModsDotGroovy.groovy
@@ -351,12 +351,21 @@ class ModsDotGroovy {
             httpClient ?= HttpClient.newBuilder().build()
             // it's a GitHub URL, so let's see if it has an update.json file on the repo in any of the standard locations
             final String updateJsonUrlRoot = "https://raw.githubusercontent.com/${ghMatcher.group(1)}/${ghMatcher.group(2)}/${ghMatcher.group(3) ?: 'master'}"
-            final String[] updateJsonUrls = [
+            final List updateJsonUrls = [
                     "${updateJsonUrlRoot}/src/main/resources/update.json",
                     "${updateJsonUrlRoot}/src/main/resources/updates.json",
                     "${updateJsonUrlRoot}/update.json",
                     "${updateJsonUrlRoot}/updates.json"
             ]
+            if (updateJsonUrlRoot.endsWith('master')) {
+                final String updateJsonUrlMainBranchRoot = updateJsonUrlRoot[0..-6] + 'main'
+                updateJsonUrls.addAll([
+                        "${updateJsonUrlMainBranchRoot}/src/main/resources/update.json",
+                        "${updateJsonUrlMainBranchRoot}/src/main/resources/updates.json",
+                        "${updateJsonUrlMainBranchRoot}/update.json",
+                        "${updateJsonUrlMainBranchRoot}/updates.json"
+                ])
+            }
 
             // todo: check if the updates.json file exists locally and skip the network request if it does
 

--- a/src/lib/groovy/ModsDotGroovy.groovy
+++ b/src/lib/groovy/ModsDotGroovy.groovy
@@ -53,7 +53,7 @@ class ModsDotGroovy {
      * Run a given block only if the plugin is configuring the mods.toml file for forge.
      */
     void onForge(Closure closure) {
-        if (platform == Platform.FORGE) {
+        if (platform === Platform.FORGE) {
             closure.resolveStrategy = DELEGATE_FIRST
             closure.call()
         }
@@ -102,7 +102,7 @@ class ModsDotGroovy {
      * For GroovyModLoader @GMod mods it should be {@code gml}.
      */
     void setModLoader(String modLoader) {
-       if (platform == Platform.FORGE)
+       if (platform === Platform.FORGE)
             put 'modLoader', modLoader
     }
 
@@ -110,7 +110,7 @@ class ModsDotGroovy {
      * A version range to match for the {@link #setModLoader(java.lang.String)}.
      */
     void setLoaderVersion(String loaderVersion) {
-        if (platform == Platform.FORGE)
+        if (platform === Platform.FORGE)
             put 'loaderVersion', VersionRange.of(loaderVersion).toForge()
     }
 
@@ -118,7 +118,7 @@ class ModsDotGroovy {
      * A version range to match for the {@link #setModLoader(java.lang.String)}.
      */
     void setLoaderVersion(List<String> loaderVersion) {
-        if (platform == Platform.FORGE) {
+        if (platform === Platform.FORGE) {
             final VersionRange range = new VersionRange()
             range.versions = loaderVersion.collectMany {VersionRange.of(it).versions}
             put 'loaderVersion', range.toForge()
@@ -303,6 +303,8 @@ class ModsDotGroovy {
      */
     @Nullable
     String inferUpdateJsonUrl(final ImmutableModInfo modInfo) {
+        if (platform !== Platform.FORGE) return null
+
         final String displayOrIssueTrackerUrl = modInfo.displayUrl ?: ((String) data.issueTrackerUrl)
         if (displayOrIssueTrackerUrl.is null) return null
 

--- a/src/lib/groovy/ModsDotGroovy.groovy
+++ b/src/lib/groovy/ModsDotGroovy.groovy
@@ -5,13 +5,21 @@
 
 //file:noinspection GrMethodMayBeStatic
 
+import groovy.json.JsonParserType
+import groovy.json.JsonSlurper
 import groovy.transform.CompileStatic
 import groovy.transform.stc.ClosureParams
 import groovy.transform.stc.SimpleType
+import groovyjarjarantlr4.v4.runtime.misc.Nullable
 import modsdotgroovy.ImmutableModInfo
 import modsdotgroovy.ModInfoBuilder
 import modsdotgroovy.ModsBuilder
 import modsdotgroovy.VersionRange
+
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.util.regex.Matcher
 
 import static groovy.lang.Closure.DELEGATE_FIRST
 
@@ -153,8 +161,8 @@ class ModsDotGroovy {
                 modData['modId'] = modInfo.modId
                 modData['version'] = modInfo.version
                 modData['displayName'] = modInfo.displayName
-                modData['updateJsonUrl'] = modInfo.updateJsonUrl
                 modData['displayUrl'] = modInfo.displayUrl
+                modData['updateJsonUrl'] = modInfo.updateJsonUrl ?: inferUpdateJsonUrl(modInfo)
                 modData['credits'] = modInfo.credits
                 modData['logoFile'] = modInfo.logoFile
                 modData['description'] = modInfo.description
@@ -286,5 +294,81 @@ class ModsDotGroovy {
         closure.call(val)
         val.sanitize()
         return val
+    }
+
+    /**
+     * Infers the updateJsonUrl from the provided modInfo.
+     * @param modInfo
+     * @return the inferred updateJsonUrl, or null if it could not be inferred
+     */
+    @Nullable
+    String inferUpdateJsonUrl(final ImmutableModInfo modInfo) {
+        final String displayOrIssueTrackerUrl = modInfo.displayUrl ?: ((String) data.issueTrackerUrl)
+        if (displayOrIssueTrackerUrl.is null) return null
+
+        @Nullable
+        HttpClient httpClient = null
+
+        // determine if the displayUrl is a CurseForge URL and if so, extract the project ID and slug from it if possible
+        // and use those to construct an updateJsonUrl using forge.curseupdate.com
+        // example in: https://www.curseforge.com/minecraft/mc-mods/spammycombat?projectId=623297
+        // example out: 623297/spammycombat
+        final Matcher cfMatcher = displayOrIssueTrackerUrl =~ $/.*curseforge.com/minecraft/mc-mods/([^?/]+)\?projectId=(\d+)/$
+        if (cfMatcher.matches()) {
+            httpClient ?= HttpClient.newBuilder().build()
+            // determine the modId first from the modId, falling back to the slug in the URL if that fails
+            final String updateJsonUrlRoot = "https://forge.curseupdate.com/${cfMatcher.group(2)}/"
+            final String[] updateJsonUrls = [
+                    updateJsonUrlRoot + modInfo.modId,
+                    updateJsonUrlRoot + cfMatcher.group(1)
+            ]
+
+            // make a GET request to the updateJsonUrl and to see if it's valid
+            final jsonSlurper = new JsonSlurper().setType(JsonParserType.INDEX_OVERLAY)
+            for (final String url in updateJsonUrls) {
+                final HttpRequest request = HttpRequest.newBuilder(URI.create(url)).GET().build()
+                try {
+                    final HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+                    if (response.statusCode() === HttpURLConnection.HTTP_OK) {
+                        final json = jsonSlurper.parseText(response.body())
+                        if (!(json?.getAt('promos') as Map).isEmpty())
+                            return url
+                    }
+                } catch (final IOException ignored) {}
+            }
+        }
+
+        // todo: create a web service that returns the projectId from a given slug and use that to avoid the need for
+        // explicitly specifying the projectId in the displayUrl
+
+        // determine if the displayUrl is a GitHub URL and if so, see if it has an updates.json file next to the mods.groovy
+        // example in: https://github.com/PaintNinja/Ninjas-Cash
+        // example out: https://raw.githubusercontent.com/PaintNinja/Ninjas-Cash/master/src/main/resources/updates.json
+        final Matcher ghMatcher = displayOrIssueTrackerUrl =~ $/.*github.com/([^?/]+)/([^?/]+)(?:/tree/([^?/]+))?/?/$
+        if (ghMatcher.matches()) {
+            httpClient ?= HttpClient.newBuilder().build()
+            // it's a GitHub URL, so let's see if it has an update.json file on the repo in any of the standard locations
+            final String updateJsonUrlRoot = "https://raw.githubusercontent.com/${ghMatcher.group(1)}/${ghMatcher.group(2)}/${ghMatcher.group(3) ?: 'master'}"
+            final String[] updateJsonUrls = [
+                    "${updateJsonUrlRoot}/src/main/resources/update.json",
+                    "${updateJsonUrlRoot}/src/main/resources/updates.json",
+                    "${updateJsonUrlRoot}/update.json",
+                    "${updateJsonUrlRoot}/updates.json"
+            ]
+
+            // todo: check if the updates.json file exists locally and skip the network request if it does
+
+            // make a HEAD request to the updateJsonUrl to see if it exists using HttpClient
+            for (final String url in updateJsonUrls) {
+                final HttpRequest request = HttpRequest.newBuilder(URI.create(url)).method("HEAD", HttpRequest.BodyPublishers.noBody()).build()
+                try {
+                    final HttpResponse<Void> response = httpClient.send(request, HttpResponse.BodyHandlers.discarding())
+                    if (response.statusCode() === HttpURLConnection.HTTP_OK)
+                        return url
+                } catch (final IOException ignored) {}
+            }
+        }
+
+        return null
     }
 }

--- a/src/lib/groovy/ModsDotGroovy.groovy
+++ b/src/lib/groovy/ModsDotGroovy.groovy
@@ -380,6 +380,37 @@ class ModsDotGroovy {
             }
         }
 
+        final Matcher mrMatcher = modInfo.displayUrl =~ $/.*modrinth.com/mod/([^?/]+)/?/$
+        println "displayUrl: ${modInfo.displayUrl}"
+        println "matches? ${mrMatcher.matches()}"
+        if (mrMatcher.matches()) {
+            httpClient ?= HttpClient.newBuilder().build()
+            final String updateJsonUrl = "https://api.modrinth.com/updates/${mrMatcher.group(1)}/forge_updates.json"
+
+            // modrinth's api doesn't factor in the actual mod jar's mods.toml version - just the published version,
+            // so we need to check that the returned promos map contains the mod's current version to avoid constantly
+            // nagging for updates the user might already have
+            final jsonSlurper = new JsonSlurper().setType(JsonParserType.INDEX_OVERLAY)
+            final HttpRequest request = HttpRequest.newBuilder(URI.create(updateJsonUrl)).GET().build()
+            try {
+                final HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+                println response.statusCode()
+                if (response.statusCode() === HttpURLConnection.HTTP_OK) {
+                    final json = jsonSlurper.parseText(response.body())
+                    @Nullable final Map promos = json?.getAt('promos') as Map
+                    println "promos: ${promos}"
+                    if (promos !== null && !promos?.isEmpty()) {
+                        println "values: ${promos.values()}"
+                        println "contains? ${promos.values().contains(modInfo.version)}"
+                        if (promos.values().contains(modInfo.version))
+                            return updateJsonUrl
+                    }
+                }
+            } catch (final IOException ignored) {
+                println "ioexception"
+            }
+        }
+
         return null
     }
 }


### PR DESCRIPTION
This feature attempts to infer an updateJsonUrl from the displayUrl or issueTrackerUrl if either present, in that order.

CurseForge and GitHub links are supported:
Example 1
```groovy
displayUrl = 'https://curseforge.com/minecraft/mc-mods/spammycombat?projectId=623297'
```
```groovy
// inferred updateJsonUrl
updateJsonUrl = 'https://forge.curseupdate.com/623297/spammycombat'
```

Example 2
```groovy
issueTrackerUrl = 'https://github.com/zlepper/itlt/issues'
```
```groovy
// inferred updateJsonUrl
updateJsonUrl = 'https://raw.githubusercontent.com/zlepper/itlt/master/updates.json'
```

The following scenarios have been tested:
- https://curseforge.com/minecraft/mc-mods/spammycombat?projectId=623297 (missing `www.`)
- https://curseforge.com/minecraft/mc-mods/spammycombat?projectId=623297 (missing `https://www.`)
- https://www.curseforge.com/minecraft/mc-mods/variable-spawner-hardness?projectId=400396 (different slug from modId)
- https://github.com/zlepper/itlt/issues (assumes `master` branch)
- https://github.com/zlepper/itlt/ (trailing slash)
- https://github.com/zlepper/itlt
- https://github.com/zlepper/itlt/tree/1.17 (searches for an update(s).json in the `1.17` branch)