### PR TITLE
Extra maps

### DIFF
--- a/Test/build.gradle
+++ b/Test/build.gradle
@@ -6,7 +6,7 @@ plugins {
 java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
 modsDotGroovy {
-    dslVersion = '1.1.3'
+    dslVersion = '1.2.0'
     platforms 'forge', 'quilt'
 }
 

--- a/Test/src/main/resources/mods.groovy
+++ b/Test/src/main/resources/mods.groovy
@@ -63,4 +63,10 @@ ModsDotGroovy.make {
     onQuilt {
         mixin = "no.mixin.json"
     }
+
+    extraMaps = [
+            'packMcMeta': [
+                    'hi': 'no'
+            ]
+    ]
 }

--- a/Test/src/main/resources/mods.groovy
+++ b/Test/src/main/resources/mods.groovy
@@ -64,9 +64,9 @@ ModsDotGroovy.make {
         mixin = "no.mixin.json"
     }
 
-    extraMaps = [
-            'packMcMeta': [
-                    'hi': 'no'
-            ]
-    ]
+    packMcMeta {
+        packFormat = 6
+        forgeDataPackFormat = 4
+        description = 'The resources of a lovely mod'
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.parallel=true
 org.gradle.caching=true
 
 version=1.1.2
-dsl_version=1.1.3
+dsl_version=1.2.0

--- a/src/lib/groovy/modsdotgroovy/PackMcMetaBuilder.groovy
+++ b/src/lib/groovy/modsdotgroovy/PackMcMetaBuilder.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022 GroovyMC
+ * SPDX-License-Identifier: MIT
+ */
+
+package modsdotgroovy
+
+import groovy.transform.CompileStatic
+
+@CompileStatic
+class PackMcMetaBuilder extends HashMap {
+    void setDescription(String description) {
+        packMap['description'] = description
+    }
+
+    void setPackFormat(int packFormat) {
+        packMap['pack_format'] = packFormat
+    }
+
+    void setForgeResourcePackFormat(int packFormat) {
+        packMap['forge:resource_pack_format'] = packFormat
+    }
+
+    void setForgeDataPackFormat(int packFormat) {
+        packMap['forge:data_pack_format'] = packFormat
+    }
+
+    private Map getPackMap() {
+        (Map)computeIfAbsent('pack') { new HashMap<>() }
+    }
+}

--- a/src/main/groovy/io/github/groovymc/modsdotgroovy/AbstractConvertTask.groovy
+++ b/src/main/groovy/io/github/groovymc/modsdotgroovy/AbstractConvertTask.groovy
@@ -97,8 +97,8 @@ if (ModsDotGroovy.metaClass.respondsTo(null,'setPlatform')) {
         catalogs.convention(['libs'])
         project.afterEvaluate {
             arguments.put('buildProperties', project.extensions.extraProperties.properties)
-            catalogs.get().each {
-                arg(it, versionCatalogToMap(getLibsExtension(project, it)))
+            catalogs.get().forEach { String id ->
+                arg(id, versionCatalogToMap(getLibsExtension(project, id)))
             }
             arg('version', project.version)
             arg('platform', getPlatform())

--- a/src/main/groovy/io/github/groovymc/modsdotgroovy/ConvertToQuiltJsonTask.groovy
+++ b/src/main/groovy/io/github/groovymc/modsdotgroovy/ConvertToQuiltJsonTask.groovy
@@ -5,12 +5,16 @@
 
 package io.github.groovymc.modsdotgroovy
 
-import com.google.gson.GsonBuilder
+import groovy.transform.CompileStatic
 
+@CompileStatic
 abstract class ConvertToQuiltJsonTask extends AbstractConvertTask {
+
     @Override
-    protected String getOutputName() {
-        return 'quilt.mod.json'
+    protected void registerStrategies() {
+        register('root', new Strategy(
+                'quilt.mod.json', '', JSON_WRITER
+        ))
     }
 
     @Override
@@ -33,19 +37,6 @@ abstract class ConvertToQuiltJsonTask extends AbstractConvertTask {
         if (quiltLoaderDependency !== null) {
             arg('quiltLoaderVersion', quiltLoaderDependency.version)
         }
-    }
-
-    @Override
-    protected String writeData(Map data) {
-        final gson = new GsonBuilder()
-                .setPrettyPrinting()
-                .create()
-        return gson.toJson(data)
-    }
-
-    @Override
-    protected String getOutputDir() {
-        return ''
     }
 
     @Override

--- a/src/main/groovy/io/github/groovymc/modsdotgroovy/ConvertToTomlTask.groovy
+++ b/src/main/groovy/io/github/groovymc/modsdotgroovy/ConvertToTomlTask.groovy
@@ -5,14 +5,19 @@
 
 package io.github.groovymc.modsdotgroovy
 
-import com.moandjiezana.toml.TomlWriter
 import groovy.transform.CompileStatic
 
 @CompileStatic
 abstract class ConvertToTomlTask extends AbstractConvertTask {
+
     @Override
-    protected String getOutputName() {
-        return 'mods.toml'
+    protected void registerStrategies() {
+        register('root', new Strategy(
+                'mods.toml', 'META-INF', TOML_WRITER
+        ))
+        register('packMcMeta', new Strategy(
+                'pack.mcmeta', '', JSON_WRITER
+        ))
     }
 
     @Override
@@ -32,20 +37,6 @@ abstract class ConvertToTomlTask extends AbstractConvertTask {
                 } catch (Exception ignored) {}
             }
         }
-    }
-
-    @Override
-    protected String writeData(Map data) {
-        final tomlWriter = new TomlWriter.Builder()
-                .indentValuesBy(2)
-                .indentTablesBy(4)
-                .build()
-        return tomlWriter.write(data)
-    }
-
-    @Override
-    protected String getOutputDir() {
-        return 'META-INF'
     }
 
     @Override

--- a/src/main/groovy/io/github/groovymc/modsdotgroovy/ModsDotGroovy.groovy
+++ b/src/main/groovy/io/github/groovymc/modsdotgroovy/ModsDotGroovy.groovy
@@ -112,11 +112,7 @@ class ModsDotGroovy implements Plugin<Project> {
             it.getInput().set(modsGroovy.file)
         }
         project.tasks.named(modsGroovy.sourceSet.processResourcesTaskName, ProcessResources).configure {
-            exclude((FileTreeElement el) -> el.file == convertTask.input.get().asFile)
-            dependsOn(convertTask)
-            from(convertTask.output.get().asFile) {
-                into 'META-INF'
-            }
+            convertTask.setupOnProcessResources(it, (FileTreeElement el) -> el.file == convertTask.input.get().asFile)
         }
         return convertTask
     }
@@ -126,11 +122,7 @@ class ModsDotGroovy implements Plugin<Project> {
             it.getInput().set(modsGroovy.file)
         }
         project.tasks.named(modsGroovy.sourceSet.processResourcesTaskName, ProcessResources).configure {
-            exclude((FileTreeElement el) -> el.file == convertTask.input.get().asFile)
-            dependsOn(convertTask)
-            from(convertTask.output.get().asFile) {
-                into ''
-            }
+            convertTask.setupOnProcessResources(it, (FileTreeElement el) -> el.file == convertTask.input.get().asFile)
         }
         return convertTask
     }


### PR DESCRIPTION
This PR implements extra maps, which are used for additional files (like `pack.mcmeta` and mixin json files)
For now, only a `pack.mcmeta` extra map is implemented, in the forge version.
Note: this PR was practically not possible without the breaking changes to `AbstractConvertTask`.