### PR TITLE
Fix displayUrl and updateJsonUrl generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Then, you need to decide on a ModsDotGroovy DSL version which you want to use. Y
 Add the following line in your `build.gradle`, to do so:
 ```gradle
 modsDotGroovy {
-    dslVersion = '1.1.3' // Can be replaced with any existing DSL version
+    dslVersion = '1.2.1' // Can be replaced with any existing DSL version
     platform 'forge'
 }
 ```

--- a/Test/build.gradle
+++ b/Test/build.gradle
@@ -6,7 +6,7 @@ plugins {
 java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
 modsDotGroovy {
-    dslVersion = '1.2.0'
+    dslVersion = '1.2.1'
     platforms 'forge', 'quilt'
 }
 

--- a/Test/gradle.properties
+++ b/Test/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.parallel=true
 org.gradle.caching=true
 
-someProperty=hello_world
+credits=Thanks to the mods.groovy contributors

--- a/Test/src/main/resources/mods.groovy
+++ b/Test/src/main/resources/mods.groovy
@@ -5,8 +5,8 @@ ModsDotGroovy.make {
     license = 'MIT'
 
     mod {
-        modId = 'no'
-        version = '1.190'
+        modId = 'examplemod'
+        version = '1.0.0'
 
         contributors = [
                 Owner: ['GroovyMC'],
@@ -14,7 +14,7 @@ ModsDotGroovy.make {
         ]
 
         contact.source = 'https://github.com/GroovyMC/ModsDotGroovy'
-        credits = "${buildProperties.someProperty}"
+        credits = "${buildProperties.credits}"
 
         // for testing the inferred updateJsonUrl feature - issueTrackerUrl and links to GitHub repos are also supported by this feature
         displayUrl = 'https://curseforge.com/minecraft/mc-mods/spammycombat?projectId=623297'

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.parallel=true
 org.gradle.caching=true
 
 version=1.1.2
-dsl_version=1.2.0
+dsl_version=1.2.1

--- a/src/lib/groovy/ModsDotGroovy.groovy
+++ b/src/lib/groovy/ModsDotGroovy.groovy
@@ -161,8 +161,8 @@ class ModsDotGroovy {
                 modData['modId'] = modInfo.modId
                 modData['version'] = modInfo.version
                 modData['displayName'] = modInfo.displayName
-                modData['displayUrl'] = modInfo.displayUrl
-                modData['updateJsonUrl'] = modInfo.updateJsonUrl ?: inferUpdateJsonUrl(modInfo)
+                modData['displayURL'] = modInfo.displayUrl
+                modData['updateJSONURL'] = modInfo.updateJsonUrl ?: inferUpdateJsonUrl(modInfo)
                 modData['credits'] = modInfo.credits
                 modData['logoFile'] = modInfo.logoFile
                 modData['description'] = modInfo.description
@@ -321,8 +321,9 @@ class ModsDotGroovy {
     String inferUpdateJsonUrl(final ImmutableModInfo modInfo) {
         if (platform !== Platform.FORGE) return null
 
-        final String displayOrIssueTrackerUrl = modInfo.displayUrl ?: ((String) data.issueTrackerUrl)
-        if (displayOrIssueTrackerUrl.is null) return null
+        final String displayOrIssueTrackerUrl = modInfo.displayUrl ?: ((String) data.issueTrackerUrl) ?: ''
+        if (displayOrIssueTrackerUrl === null || displayOrIssueTrackerUrl.isEmpty() || displayOrIssueTrackerUrl.isAllWhitespace())
+            return null
 
         @Nullable
         HttpClient httpClient = null


### PR DESCRIPTION
Whoops, looks like the generated mods.toml was outputting "displayUrl" and "updateJsonUrl" but Forge expects "displayURL" and "updateJSONURL".

Also fixed an edge-case bug in updateJsonUrl inference and updated the test mods.groovy