### PR TITLE
Add displayTest

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Then, you need to decide on a ModsDotGroovy DSL version which you want to use. Y
 Add the following line in your `build.gradle`, to do so:
 ```gradle
 modsDotGroovy {
-    dslVersion = '1.2.1' // Can be replaced with any existing DSL version
+    dslVersion = '1.3.0' // Can be replaced with any existing DSL version
     platform 'forge'
 }
 ```

--- a/Test/build.gradle
+++ b/Test/build.gradle
@@ -6,7 +6,7 @@ plugins {
 java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
 modsDotGroovy {
-    dslVersion = '1.2.2'
+    dslVersion = '1.3.0'
     platforms 'forge', 'quilt'
 }
 

--- a/Test/src/main/resources/mods.groovy
+++ b/Test/src/main/resources/mods.groovy
@@ -19,6 +19,8 @@ ModsDotGroovy.make {
         // for testing the inferred updateJsonUrl feature - issueTrackerUrl and links to GitHub repos are also supported by this feature
         displayUrl = 'https://curseforge.com/minecraft/mc-mods/spammycombat'
 
+        displayTest = DisplayTest.IGNORE_SERVER_VERSION
+
         onForge {
             customProperty = 'hello'
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.parallel=true
 org.gradle.caching=true
 
 version=1.1.2
-dsl_version=1.2.2
+dsl_version=1.3.0

--- a/src/lib/groovy/DisplayTest.groovy
+++ b/src/lib/groovy/DisplayTest.groovy
@@ -1,0 +1,25 @@
+import groovy.transform.CompileStatic
+
+@CompileStatic
+enum DisplayTest {
+    /**
+     * A red "X" will be displayed on the server connection screen if the version of this mod differs between the
+     * client and server.
+     */
+    MATCH_VERSION,
+    /**
+     * When determining whether to show a red "X" on the server connection screen, if and only if this mod is present on
+     * the server but not the client, it will be ignored.
+     */
+    IGNORE_SERVER_VERSION,
+    /**
+     * This mod will be ignored entirely when determining whether to show a red "X" on the server connection screen.
+     */
+    IGNORE_ALL_VERSION,
+    /**
+     * You are setting your own display test for your mod using Forge's API.
+     */
+    NONE
+
+    DisplayTest() {}
+}

--- a/src/lib/groovy/DisplayTest.groovy
+++ b/src/lib/groovy/DisplayTest.groovy
@@ -3,7 +3,7 @@ import groovy.transform.CompileStatic
 @CompileStatic
 enum DisplayTest {
     /**
-     * A red "X" will be displayed on the server connection screen if the version of this mod differs between the
+     * (default) A red "X" will be displayed on the server connection screen if the version of this mod differs between the
      * client and server.
      */
     MATCH_VERSION,

--- a/src/lib/groovy/ModsDotGroovy.groovy
+++ b/src/lib/groovy/ModsDotGroovy.groovy
@@ -164,6 +164,8 @@ class ModsDotGroovy {
                 modData['modId'] = modInfo.modId
                 modData['version'] = modInfo.version
                 modData['displayName'] = modInfo.displayName
+                if (modInfo.displayTest != DisplayTest.MATCH_VERSION) // no need to include it for the default version
+                    modData['displayTest'] = modInfo.displayTest.name()
                 modData['displayURL'] = modInfo.displayUrl
                 modData['updateJSONURL'] = modInfo.updateJsonUrl ?: inferUpdateJsonUrl(modInfo)
                 modData['credits'] = modInfo.credits

--- a/src/lib/groovy/modsdotgroovy/ImmutableModInfo.groovy
+++ b/src/lib/groovy/modsdotgroovy/ImmutableModInfo.groovy
@@ -29,6 +29,7 @@ class ImmutableModInfo {
     List<Dependency> dependencies
     Map customProperties
     Map entrypoints
+    DisplayTest displayTest
 
     ImmutableQuiltModInfo quiltModInfo
 }

--- a/src/lib/groovy/modsdotgroovy/ModInfoBuilder.groovy
+++ b/src/lib/groovy/modsdotgroovy/ModInfoBuilder.groovy
@@ -59,8 +59,7 @@ class ModInfoBuilder {
     /**
      * Display Test controls the display for your mod in the server connection screen.<br>
      */
-    // TODO make enum, and actually support
-    //@Nullable String displayTest = null
+    DisplayTest displayTest = DisplayTest.MATCH_VERSION
 
     /**
      * A multi-line description text for the mod, displayed in the in-game Mods screen. <br>
@@ -187,6 +186,7 @@ class ModInfoBuilder {
                 this.dependencies,
                 this.properties,
                 this.entrypoints,
+                this.displayTest,
                 quiltInfo)
     }
 }


### PR DESCRIPTION
Adds a system for setting Forge's displayTest. Groovydocs are based on the info in [the MDK](https://github.com/cpw/MinecraftForge/blob/73c1934e7ef931bafbafd0ceb6dce4cdd5dc02a2/mdk/src/main/resources/META-INF/mods.toml).