### PR TITLE
Support `minecraft = 19.4..20.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ YOu can install the plugin via the following block in the `build.gradle` file. T
 ```gradle
 plugins {
     // Other plugins here
-    id 'org.groovymc.modsdotgroovy' version '1.3.1' // Version can be replaced with any existing plugin version
+    id 'org.groovymc.modsdotgroovy' version '1.4.0' // Version can be replaced with any existing plugin version
 }
 ```
 Then, you need to decide on a ModsDotGroovy DSL version which you want to use. You can browse all available versions [here](https://maven.moddinginquisition.org/#/releases/io/github/groovymc/modsdotgroovy/dsl).
 Add the following line in your `build.gradle`, to do so:
 ```gradle
 modsDotGroovy {
-    dslVersion = '1.4.0' // Can be replaced with any existing DSL version
-    platform 'forge'
+    dslVersion = '1.5.0' // Can be replaced with any existing DSL version
+    platform = 'forge'
 }
 ```
 ## Usage
@@ -79,7 +79,7 @@ To configure the plugin for Quilt, add the following to your `build.gradle`:
 ```gradle
 modsDotGroovy {
     //...
-    platform 'quilt'
+    platform = 'quilt'
 }
 ```
 Certain Quilt-specific DSL elements exist; the `this.quiltLoaderVersion` property can be used to get the version of quilt-loader
@@ -89,7 +89,7 @@ To configure the plugin for Fabric, add the following to your `build.gradle`:
 ```gradle
 modsDotGroovy {
     //...
-    platform 'fabric'
+    platform = 'fabric'
 }
 ```
 Certain Fabric-specific DSL elements exist; the `this.fabricLoaderVersion` property can be used to get the version of fabric-loader
@@ -100,7 +100,7 @@ To configure the plugin for a multiloader project instead, insert the following 
 ```gradle
 modsDotGroovy {
     //...
-    platform 'multiloader'
+    platform = 'multiloader'
 }
 ```
 The plugin assumes that your subprojects for Quilt, Fabric, Forge, and common code are called `Quilt`, `Fabric`, `Forge`, and `Common` respectively.
@@ -108,7 +108,7 @@ If this is not the case, it can be configured as follows:
 ```gradle
 modsDotGroovy {
     //...
-    platform 'multiloader'
+    platform = 'multiloader'
     multiloader { // You do not need to have subprojects for all mod loaders
         common = project(':common')
         quilt = [project(':quilt')]

--- a/Test/build.gradle
+++ b/Test/build.gradle
@@ -2,13 +2,13 @@ import io.github.groovymc.modsdotgroovy.AbstractConvertTask
 
 plugins {
     id 'java'
-    id 'org.groovymc.modsdotgroovy' version '1.2.0'
+    id 'org.groovymc.modsdotgroovy' version '1.4.0'
 }
 
 java.toolchain.languageVersion = JavaLanguageVersion.of(17)
 
 modsDotGroovy {
-    dslVersion = '1.4.0'
+    dslVersion = '1.5.0'
     platforms 'forge', 'quilt', 'fabric'
 }
 

--- a/Test/demo/mods.toml
+++ b/Test/demo/mods.toml
@@ -36,7 +36,7 @@ license = "MIT"
 
     [[dependencies.examplemod]]
       mandatory = true
-      versionRange = "[1.19.4,1.20.0)"
+      versionRange = "[1.19.4,1.20)"
       ordering = "NONE"
       side = "BOTH"
       modId = "minecraft"

--- a/Test/demo/mods.toml
+++ b/Test/demo/mods.toml
@@ -36,7 +36,7 @@ license = "MIT"
 
     [[dependencies.examplemod]]
       mandatory = true
-      versionRange = "[1.19,1.20)"
+      versionRange = "[1.19.4,1.20.0)"
       ordering = "NONE"
       side = "BOTH"
       modId = "minecraft"

--- a/Test/src/main/resources/mods.groovy
+++ b/Test/src/main/resources/mods.groovy
@@ -31,7 +31,8 @@ ModsDotGroovy.make {
         }
 
         dependencies {
-            minecraft = 1.19..1.20 // equivalent to `minecraft = '[1.19,1.20)'`
+            //minecraft = 1.19..1.20 // equivalent to `minecraft = '[1.19,1.20)'`
+            minecraft = 19.4..20.0 // equivalent to `minecraft = '[1.19.4,1.20)'`
             forge = '[43.0.0,)' // equivalent to `forge { versionRange = '[43.0.0,)' }`
             quiltLoader = '>=0.17.3'
             fabricLoader = '[0.14.19,)'

--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,7 @@ tasks.withType(GroovyCompile).configureEach {
 
 publishing {
     publications {
-        mavenDsl(MavenPublication) {
+        register('mavenDsl', MavenPublication) {
             groupId = project.hasProperty('inquisitionPublish') ? 'io.github.groovymc.modsdotgroovy' : 'org.groovymc.modsdotgroovy'
             artifactId = 'dsl'
             version = project.dsl_version

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 org.gradle.parallel=true
 org.gradle.caching=true
 
-version=1.3.1
-dsl_version=1.4.0
+version=1.4.0
+dsl_version=1.5.0

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,7 @@
 rootProject.name = 'ModsDotGroovy'
+
+buildCache {
+    remote(HttpBuildCache) {
+        url = 'https://gradlecache.groovymc.org/cache/'
+    }
+}

--- a/src/lib/groovy/DisplayTest.groovy
+++ b/src/lib/groovy/DisplayTest.groovy
@@ -1,3 +1,8 @@
+/*
+ * Copyright (c) 2022 GroovyMC
+ * SPDX-License-Identifier: MIT
+ */
+
 import groovy.transform.CompileStatic
 
 @CompileStatic

--- a/src/lib/groovy/ModsDotGroovy.groovy
+++ b/src/lib/groovy/ModsDotGroovy.groovy
@@ -74,7 +74,7 @@ class ModsDotGroovy {
      * Run a given block only if the plugin is configuring the quilt.mod.json file for quilt.
      */
     void onQuilt(Closure closure) {
-        if (platform == Platform.QUILT) {
+        if (platform === Platform.QUILT) {
             closure.resolveStrategy = DELEGATE_FIRST
             closure.call()
         }
@@ -84,7 +84,7 @@ class ModsDotGroovy {
      * Run a given block only if the plugin is configuring the fabric.mod.json file for Fabric.
      */
     void onFabric(Closure closure) {
-        if (platform == Platform.FABRIC) {
+        if (platform === Platform.FABRIC) {
             closure.resolveStrategy = DELEGATE_FIRST
             closure.call()
         }
@@ -94,7 +94,7 @@ class ModsDotGroovy {
      * Run a given block only if the plugin is configuring the fabric.mod.json file for Fabric or the quilt.mod.json file for Quilt.
      */
     void onFabricAndQuilt(Closure closure) {
-        if (platform == Platform.FABRIC || platform == Platform.QUILT) {
+        if (platform === Platform.FABRIC || platform === Platform.QUILT) {
             closure.resolveStrategy = DELEGATE_FIRST
             closure.call()
         }
@@ -371,8 +371,8 @@ class ModsDotGroovy {
                 break
             default:
                 parts.eachWithIndex { String entry, int i ->
-                    if (i == 0) fullString = entry
-                    else if (i == parts.size() - 1) fullString += ' and ' + entry
+                    if (i === 0) fullString = entry
+                    else if (i === parts.size() - 1) fullString += ' and ' + entry
                     else fullString += ', ' + entry
                 }
                 break

--- a/src/lib/groovy/modsdotgroovy/DependenciesBuilder.groovy
+++ b/src/lib/groovy/modsdotgroovy/DependenciesBuilder.groovy
@@ -62,7 +62,9 @@ class DependenciesBuilder extends HashMap {
 
     void setMinecraft(final NumberRange versionRange) {
         final minecraftDependency = new MinecraftDependency()
-        final String mavenVersionRange = "[${versionRange.from},${versionRange.to})"
+        final String mavenVersionRange = "${versionRange.from}".startsWith('1.')
+                ? "[${versionRange.from},${versionRange.to})"
+                : "[1.${versionRange.from},1.${versionRange.to})"
         minecraftDependency.versionRange = mavenVersionRange
         dependencies << minecraftDependency.copy()
     }
@@ -74,7 +76,7 @@ class DependenciesBuilder extends HashMap {
 
     void forge(@DelegatesTo(value = ForgeDependency, strategy = DELEGATE_FIRST)
                @ClosureParams(value = SimpleType, options = 'modsdotgroovy.ForgeDependency') final Closure closure) {
-        if (platform == Platform.FORGE) {
+        if (platform === Platform.FORGE) {
             final forgeDependency = new ForgeDependency()
             closure.delegate = forgeDependency
             closure.resolveStrategy = DELEGATE_FIRST
@@ -84,7 +86,7 @@ class DependenciesBuilder extends HashMap {
     }
 
     void setForge(final String versionRange) {
-        if (platform == Platform.FORGE) {
+        if (platform === Platform.FORGE) {
             final forgeDependency = new ForgeDependency()
             forgeDependency.versionRange = versionRange
             dependencies << forgeDependency.copy()
@@ -93,7 +95,7 @@ class DependenciesBuilder extends HashMap {
 
     void quiltLoader(@DelegatesTo(value = QuiltLoaderDependency, strategy = DELEGATE_FIRST)
                      @ClosureParams(value = SimpleType, options = 'modsdotgroovy.QuiltLoaderDependency') final Closure closure) {
-        if (platform == Platform.QUILT) {
+        if (platform === Platform.QUILT) {
             final quiltLoaderDependency = new QuiltLoaderDependency()
             closure.delegate = quiltLoaderDependency
             closure.resolveStrategy = DELEGATE_FIRST
@@ -103,7 +105,7 @@ class DependenciesBuilder extends HashMap {
     }
 
     void setQuiltLoader(final String versionRange) {
-        if (platform == Platform.QUILT) {
+        if (platform === Platform.QUILT) {
             final quiltLoaderDependency = new QuiltLoaderDependency()
             quiltLoaderDependency.versionRange = versionRange
             dependencies << quiltLoaderDependency.copy()
@@ -112,7 +114,7 @@ class DependenciesBuilder extends HashMap {
 
     void fabricLoader(@DelegatesTo(value = FabricLoaderDependency, strategy = DELEGATE_FIRST)
                      @ClosureParams(value = SimpleType, options = 'modsdotgroovy.FabricLoaderDependency') final Closure closure) {
-        if (platform == Platform.FABRIC) {
+        if (platform === Platform.FABRIC) {
             final quiltLoaderDependency = new FabricLoaderDependency()
             closure.delegate = quiltLoaderDependency
             closure.resolveStrategy = DELEGATE_FIRST
@@ -122,7 +124,7 @@ class DependenciesBuilder extends HashMap {
     }
 
     void setFabricLoader(final String versionRange) {
-        if (platform == Platform.FABRIC) {
+        if (platform === Platform.FABRIC) {
             final quiltLoaderDependency = new FabricLoaderDependency()
             quiltLoaderDependency.versionRange = versionRange
             dependencies << quiltLoaderDependency.copy()

--- a/src/lib/groovy/modsdotgroovy/DependenciesBuilder.groovy
+++ b/src/lib/groovy/modsdotgroovy/DependenciesBuilder.groovy
@@ -62,10 +62,16 @@ class DependenciesBuilder extends HashMap {
 
     void setMinecraft(final NumberRange versionRange) {
         final minecraftDependency = new MinecraftDependency()
-        final String mavenVersionRange = "${versionRange.from}".startsWith('1.')
-                ? "[${versionRange.from},${versionRange.to})"
-                : "[1.${versionRange.from},1.${versionRange.to})"
-        minecraftDependency.versionRange = mavenVersionRange
+
+        String fromVersion = "${versionRange.from}"
+        if (!fromVersion.startsWith('1.')) fromVersion = '1.' + fromVersion
+        if (fromVersion.endsWith('.0')) fromVersion = fromVersion[0..-3]
+
+        String toVersion = "${versionRange.to}"
+        if (!toVersion.startsWith('1.')) toVersion = '1.' + toVersion
+        if (toVersion.endsWith('.0')) toVersion = toVersion[0..-3]
+
+        minecraftDependency.versionRange = "[$fromVersion,$toVersion)"
         dependencies << minecraftDependency.copy()
     }
 

--- a/src/main/groovy/io/github/groovymc/modsdotgroovy/MDGExtension.groovy
+++ b/src/main/groovy/io/github/groovymc/modsdotgroovy/MDGExtension.groovy
@@ -35,21 +35,24 @@ abstract class MDGExtension {
         catalogs.set(['libs'])
     }
 
-    String mdgDsl(String version = null) {
-        version = version ?: getDslVersion().get()
+    String mdgDsl(final String version = getDslVersion().get()) {
         final spl = version.split('\\.', 3)
         return "${spl.length >= 2 ? (spl[1].toInteger() >= 4 ? 'org' : 'io.github') : 'io.github'}.groovymc.modsdotgroovy:dsl:$version"
     }
 
-    void platform(String name) {
+    void platform(final String name) {
         this.platforms.set([Platform.byName(name)])
     }
 
-    void platforms(List<String> platforms) {
+    void setPlatform(final String name) {
+        this.platform(name)
+    }
+
+    void platforms(final List<String> platforms) {
         this.platforms.set(platforms.collect {Platform.byName(it)})
     }
 
-    void platforms(String[] platforms) {
+    void platforms(final String[] platforms) {
         this.platforms(Arrays.asList(platforms))
     }
 


### PR DESCRIPTION
Adds support for omitting the constant major version 1 from the MC version range to allow specifying patch version ranges. E.g.: `19.3..19.4` is equiv to `[1.19.3,1.19.4)`.

Note that you cannot mix 1.x and x.y in version ranges to avoid confusion, so the following won't work: `19.3..1.20`

Also:
- Minor performance improvements
- Support for `modsDotGroovy { platform = 'forge' }`
- Better IDE support in build.gradle for publishing block