### PR TITLE
Change system for providing build properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ModsDotGroovy
-(todo: badge)
+[![Version](https://img.shields.io/maven-central/v/org.groovymc.modsdotgroovy/modsdotgroovy?style=for-the-badge&color=blue&label=Latest%20Version&prefix=v)](https://central.sonatype.com/artifact/org.groovymc.modsdotgroovy/modsdotgroovy/)
 
 ModsDotGroovy v2 is a tool that allows writing Minecraft mod metadata files in Groovy which is then compiled down to
 a `mods.toml`, `fabric.mod.json`, `quilt.mod.json` and/or `plugin.yml` when the mod is built.
@@ -98,27 +98,14 @@ modsDotGroovy {
 This determines the output format (for example, mods.toml for `Platform.FORGE`) as well as which plugins and frontend
 to use (unless you explicitly tell the Gradle plugin not to set up the DSL and plugins for you).
 
-### Blacklisting environment variables
-In mods.groovy, you can access build properties with `buildProperties['propertyName']`.
-
-This contains the properties from your gradle.properties file and any global ones, so you may want to blacklist them to
-avoid leaking private keys.
-
-By default, the Gradle plugin excludes properties whose name contains (case-insensitive):
-- pass
-- password
-- token
-- key
-- secret
-
-You can change the blacklist with:
+### Providing build properties
+In mods.groovy, you can access build properties you expose with `buildProperties['propertyName']`. To do so, you must
+first explicitly tell mods.groovy to include them:
 ```groovy
-modsDotGroovy {
-    environmentBlacklist = ['private']
+modsDotGroovy.gather {
+    projectProperty 'propertyName'
 }
 ```
-Note! This overwrites the default blacklist, so you should copy over the words above if you want to add new entries
-rather than replace.
 
 ### Automatic configuration and setup
 Most of the time you don't need to turn this off, but for the edge-cases where you do, you can do so with:
@@ -132,6 +119,9 @@ modsDotGroovy {
     
     // adds the stock plugins to your project
     setupPlugins = false
+  
+    // attempts to automatically infer details such as platform or minecraft version for you project
+    inferGether = false
 }
 ```
 

--- a/core/src/main/groovy/org/groovymc/modsdotgroovy/frontend/ModsDotGroovyFrontend.groovy
+++ b/core/src/main/groovy/org/groovymc/modsdotgroovy/frontend/ModsDotGroovyFrontend.groovy
@@ -8,7 +8,7 @@ abstract class ModsDotGroovyFrontend implements VersionProducer {
     private final ModsDotGroovyCore core
 
     /**@
-     * If running in a Gradle environment, this will be populated with the {@code gradle.properties}.
+     * If running in a Gradle environment, this will be populated properties exposed with modsDotGroovy.gather
      */
     public final Map<String, ?> buildProperties = [:]
 

--- a/gradle-plugin/src/main/groovy/org/groovymc/modsdotgroovy/gradle/ModsDotGroovyGradlePlugin.groovy
+++ b/gradle-plugin/src/main/groovy/org/groovymc/modsdotgroovy/gradle/ModsDotGroovyGradlePlugin.groovy
@@ -16,7 +16,6 @@ final class ModsDotGroovyGradlePlugin implements Plugin<Project> {
     void apply(Project project) {
         // setup required plugins
         project.plugins.apply('java')
-        project.plugins.apply('groovy')
 
         JavaPluginExtension javaPluginExtension = project.extensions.getByType(JavaPluginExtension)
         SourceSetContainer sourceSets = javaPluginExtension.sourceSets

--- a/gradle-plugin/src/main/groovy/org/groovymc/modsdotgroovy/gradle/tasks/AbstractMDGConvertTask.groovy
+++ b/gradle-plugin/src/main/groovy/org/groovymc/modsdotgroovy/gradle/tasks/AbstractMDGConvertTask.groovy
@@ -52,10 +52,6 @@ abstract class AbstractMDGConvertTask extends DefaultTask {
 
     @Input
     @Optional
-    abstract SetProperty<String> getEnvironmentBlacklist()
-
-    @Input
-    @Optional
     abstract Property<Platform> getPlatform()
 
     @Input
@@ -87,8 +83,6 @@ abstract class AbstractMDGConvertTask extends DefaultTask {
         // default to e.g. build/modsDotGroovyToToml/mods.toml
         output.convention(projectLayout.buildDirectory.dir('generated/modsDotGroovy/' + name.replaceFirst('ConvertTo', 'modsDotGroovyTo')).map((Directory dir) -> dir.file(outputName.get())))
 
-        environmentBlacklist.convention(project.provider(() -> conversionOptions.get().environmentBlacklist.get()))
-        buildProperties.convention(project.provider(() -> filterBuildProperties(project.extensions.extraProperties.properties, environmentBlacklist.get())))
         projectVersion.convention(project.provider(() -> project.version.toString()))
         projectGroup.convention(project.provider(() -> project.group.toString()))
         isMultiplatform.convention(project.provider(() -> false))
@@ -151,7 +145,12 @@ abstract class AbstractMDGConvertTask extends DefaultTask {
 
         final json = new JsonSlurper()
         (json.parse(platformDetailsFile.get().asFile) as Map<String, String>).each { key, value ->
-            bindingValues[key] = value
+            final original = value
+            if (original instanceof Map && value instanceof Map) {
+                bindingValues[key] = original + value
+            } else {
+                bindingValues[key] = value
+            }
         }
 
         final bindings = new Binding(bindingValues)

--- a/test/forge/build.gradle
+++ b/test/forge/build.gradle
@@ -5,6 +5,10 @@ plugins {
     id 'org.groovymc.modsdotgroovy'
 }
 
+modsDotGroovy.gather {
+    projectProperty 'credits'
+}
+
 version = '1.0.0'
 group = 'com.example.examplemod'
 base.archivesName = 'examplemod'

--- a/test/forge/src/main/resources/mods.groovy
+++ b/test/forge/src/main/resources/mods.groovy
@@ -20,11 +20,10 @@ final mdg = ForgeModsDotGroovy.make {
         displayUrl = 'https://curseforge.com/minecraft/mc-mods/spammycombat'
         // updateJsonUrl = 'https://forge.curseupdate.com/623297/spammycombat'
 
-        // TODO: make sure to pass this in for testing
         credits = buildProperties.credits
         //displayTest = DisplayTest.MATCH_VERSION
         dependencies {
-            // TODO: can we get IDE support for this?
+            // TODO: can/should we get IDE support for this? (or expose it only through the environment info?)
             forge = ">=${platformVersion}"
             minecraft = '[1.19.3]'
 

--- a/test/multiplatform/fabric/build.gradle
+++ b/test/multiplatform/fabric/build.gradle
@@ -9,6 +9,9 @@ dependencies {
     modImplementation 'net.fabricmc:fabric-loader:0.14.24'
 }
 
-modsDotGroovy.multiplatform {
-    from ':multiplatform:common'
+modsDotGroovy {
+    multiplatform.from ':multiplatform:common'
+    gather {
+        projectProperty 'credits'
+    }
 }

--- a/test/multiplatform/forge/build.gradle
+++ b/test/multiplatform/forge/build.gradle
@@ -17,6 +17,9 @@ dependencies {
     minecraft 'net.minecraftforge:forge:1.20.2-48.0.35'
 }
 
-modsDotGroovy.multiplatform {
-    from ':multiplatform:common'
+modsDotGroovy {
+    multiplatform.from ':multiplatform:common'
+    gather {
+        projectProperty 'credits'
+    }
 }

--- a/test/multiplatform/neoforge/build.gradle
+++ b/test/multiplatform/neoforge/build.gradle
@@ -11,6 +11,9 @@ modsDotGroovy {
     multiplatform {
         from ':multiplatform:common'
     }
+    gather {
+        projectProperty 'credits'
+    }
     apply()
 }
 

--- a/test/multiplatform/quilt/build.gradle
+++ b/test/multiplatform/quilt/build.gradle
@@ -9,6 +9,9 @@ dependencies {
     modImplementation 'org.quiltmc:quilt-loader:0.21.0'
 }
 
-modsDotGroovy.multiplatform {
-    from ':multiplatform:common'
+modsDotGroovy {
+    multiplatform.from ':multiplatform:common'
+    gather {
+        projectProperty 'credits'
+    }
 }

--- a/test/neoforge/build.gradle
+++ b/test/neoforge/build.gradle
@@ -10,6 +10,9 @@ versionCatalogs.find('libs')
 modsDotGroovy {
     platform = Platform.NEOFORGE
     inferGather.set false
+    gather {
+        projectProperty 'credits'
+    }
     apply()
 }
 

--- a/test/neogradle/build.gradle
+++ b/test/neogradle/build.gradle
@@ -3,6 +3,12 @@ plugins {
     id 'org.groovymc.modsdotgroovy'
 }
 
+modsDotGroovy {
+    gather {
+        projectProperty 'credits'
+    }
+}
+
 runs {
     server {
         modSource project.sourceSets.main


### PR DESCRIPTION
Also includes a couple of more minor fixes I made at the same time - notably, some logic for the mods.toml move in neo 20.5 and removing the unneeded application of the `groovy` plugin.