### PR TITLE
Remove support for legacy Loom 1.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,9 +4,9 @@ plugins {
     id 'java-platform'
     id 'maven-publish'
     id 'signing'
-    id 'net.neoforged.gradleutils' version '3.0.0-alpha.11' apply false
-    id 'io.github.gradle-nexus.publish-plugin' version '2.0.0-rc-1'
-    id 'dev.lukebemish.managedversioning' version '1.2.8'
+    id 'net.neoforged.gradleutils' version '3.0.0' apply false
+    id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
+    id 'dev.lukebemish.managedversioning' version '1.2.23'
     alias libs.plugins.rootpackagetransformer apply false
 }
 

--- a/gradle-plugin/build.gradle
+++ b/gradle-plugin/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     api projects.types
 
     implementation 'com.moandjiezana.toml:toml4j:0.7.2'
+    implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'org.yaml:snakeyaml:2.1'
 }
 

--- a/gradle-plugin/src/main/groovy/org/groovymc/modsdotgroovy/gradle/MDGExtension.groovy
+++ b/gradle-plugin/src/main/groovy/org/groovymc/modsdotgroovy/gradle/MDGExtension.groovy
@@ -26,6 +26,7 @@ import org.gradle.language.jvm.tasks.ProcessResources
 import org.groovymc.modsdotgroovy.types.core.Platform
 import org.groovymc.modsdotgroovy.types.internal.FlexVerComparator
 import org.groovymc.modsdotgroovy.gradle.tasks.*
+import org.jetbrains.annotations.Nullable
 
 import javax.inject.Inject
 
@@ -134,9 +135,9 @@ abstract class MDGExtension {
     }
 
     private static boolean isLoomProbablyPresent(Project project) {
-        var loom = project.extensions.findByName('loom')
+        final @Nullable def loomExtension = project.extensions.findByName('loom')
         // The loom extension is present and looks sort of like what we expect
-        return loom !== null && loom.hasProperty('minecraftVersion')
+        return loomExtension?.hasProperty('minecraftVersion')
     }
 
     void multiplatform(Action<Multiplatform> action) {

--- a/gradle-plugin/src/main/groovy/org/groovymc/modsdotgroovy/gradle/tasks/GatherLoomPlatformDetails.groovy
+++ b/gradle-plugin/src/main/groovy/org/groovymc/modsdotgroovy/gradle/tasks/GatherLoomPlatformDetails.groovy
@@ -44,11 +44,7 @@ abstract class GatherLoomPlatformDetails extends AbstractGatherPlatformDetailsTa
     @Override
     void run() throws IllegalStateException {
         @Nullable String minecraftVersion = this.minecraftVersion.getOrNull()
-        @Nullable String platformVersion = this.platformVersion.getOrNull()
-
-        if (platformVersion == null) {
-            platformVersion = calculatePlatformVersion()
-        }
+        @Nullable String platformVersion = this.platformVersion.getOrNull() ?: calculatePlatformVersion()
 
         this.writePlatformDetails(minecraftVersion, platformVersion)
     }
@@ -57,14 +53,8 @@ abstract class GatherLoomPlatformDetails extends AbstractGatherPlatformDetailsTa
     private Provider<String> getMCVersionFromLoom() {
         return project.provider {
             final @Nullable def loomExtension = project.extensions.findByName('loom')
-            if (loomExtension !== null && loomExtension.hasProperty('minecraftVersion')) {
+            if (loomExtension?.hasProperty('minecraftVersion')) {
                 return (String) loomExtension.minecraftVersion.get()
-            } else if (loomExtension !== null && loomExtension.hasProperty('minecraftProvider')) {
-                // The old legacy way, using an internal API if it works
-                def provider = loomExtension.minecraftProvider
-                if (provider !== null && provider.respondsTo('minecraftVersion')) {
-                    return (String) provider.minecraftVersion()
-                }
             }
             return null
         }

--- a/test/fabric/build.gradle
+++ b/test/fabric/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.4.6'
+    id 'fabric-loom' version '1.5.8'
     id 'org.groovymc.modsdotgroovy'
 }
 

--- a/test/multiplatform/fabric/build.gradle
+++ b/test/multiplatform/fabric/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.4.6'
+    id 'fabric-loom' version '1.5.8'
     id 'org.groovymc.modsdotgroovy'
 }
 

--- a/test/multiplatform/quilt/build.gradle
+++ b/test/multiplatform/quilt/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.quiltmc.loom' version '1.4.1'
+    id 'org.quiltmc.loom' version '1.5.8'
     id 'org.groovymc.modsdotgroovy'
 }
 

--- a/test/quilt/build.gradle
+++ b/test/quilt/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'org.quiltmc.loom' version '1.4.1'
+    id 'org.quiltmc.loom' version '1.5.8'
     id 'org.groovymc.modsdotgroovy'
 }
 


### PR DESCRIPTION
This PR fixes an issue with Loom 1.5+ support, uses it in tests, removes support for the older Loom 1.4 and performs some minor code cleanup.