### PR TITLE
Annotate `Platform` with `@KnownImmutable`

### DIFF
--- a/types/build.gradle
+++ b/types/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     compileOnly libs.jetbrains.annotations.get()
+    compileOnly libs.groovy4.core.get()
 }
 
 publishing {

--- a/types/src/main/java/org/groovymc/modsdotgroovy/types/core/Platform.java
+++ b/types/src/main/java/org/groovymc/modsdotgroovy/types/core/Platform.java
@@ -1,5 +1,7 @@
 package org.groovymc.modsdotgroovy.types.core;
 
+import groovy.transform.KnownImmutable;
+
 import java.io.Serializable;
 import java.util.Locale;
 import java.util.Map;
@@ -7,6 +9,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+@KnownImmutable
 public final class Platform implements Serializable {
     private final String name;
 


### PR DESCRIPTION
This offers a guarantee to the Groovy compiler that `Platform` is known to be immutable and to treat it as such